### PR TITLE
fix: Fixing the name of the `fabric_workspace` resource argument name from `capacity` to `capacity_id`

### DIFF
--- a/quickstarts/102-fabric-capacity/main.tf
+++ b/quickstarts/102-fabric-capacity/main.tf
@@ -48,6 +48,6 @@ data "fabric_capacity" "example" {
 # Create a Fabric Workspace.
 # https://registry.terraform.io/providers/microsoft/fabric/latest/docs/resources/workspace
 resource "fabric_workspace" "example" {
-  capacity     = data.fabric_capacity.example.id
+  capacity_id  = data.fabric_capacity.example.id
   display_name = "ws-${var.name}"
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

Fixing the name of the `fabric_workspace` resource argument name from `capacity` to `capacity_id` according to latest documentation of [terraform fabric provider](https://registry.terraform.io/providers/microsoft/fabric/latest/docs/resources/workspace)

- Describe the current behavior that you are modifying and link to issue number.
- If you don't have an issue, browse through existing issues to see if this is already tracked as an issue, to assign yourself to the issue and also verify that no one else is already working on the issue.

## ✨ Description of new changes

- Write a detailed description of all changes and, if appropriate, why they are needed.

According to latest documentation argument name of the resource should be updated from `capacity` to `capacity_id`. 

## ☑️ PR Checklist

- [x] Link to the issue you are addressing is included above
- [x] Ensure the PR description clearly describes the feature you're adding and any known limitations
