### PR TITLE
refactor(102fabcap): use azurerm instead of azapi for fabric capacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,63 +1,41 @@
-__pycache__
-*.dll
-*.exe
-.DS_Store
-bin/
-dist/
-build/
-modules-dev/
-/pkg/
-website/.vagrant
-website/.bundle
-website/build
-website/node_modules
-.vagrant/
-*.log
-*.bak
-*~
-.*.swp
-.idea
-*.iml
-*.test
-*.iml
-coverage.xml
-coverage.txt
-coverage.out
-coverage.html
-coverage.md
-coverage.json
-.task/
-site/
-website/vendor
-.hugo_build.lock
-.dev/
-_dev/
-__debug*
-testresults.xml
-golangci-report.xml
-.wellknown.json
-changie.md
+# Local .terraform directories
+**/.terraform/*
 
-# Terraform
-.terraform/
-*.tfplan
+# .tfstate files
 *.tfstate
-*.tfstate.backup
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
 *.lock.hcl
 *.lock.info
-*.tfrc
-
-# Test exclusions
-!command/test-fixtures/**/*.tfstate
-!command/test-fixtures/**/.terraform/
-
-# Keep windows files with windows line endings
-*.winfile eol=crlf
-
-# Ignore default go build output
-*.key
-*.pub
-*.pem
-*.crt
-*.pfx
-*.p12

--- a/quickstarts/102-fabric-capacity/README.md
+++ b/quickstarts/102-fabric-capacity/README.md
@@ -2,12 +2,13 @@
 
 ## Input Variables
 
-| Name                  | Description                     | Type   | Default | Required |
-|-----------------------|---------------------------------|--------|---------|:--------:|
-| `name`                | Name of the solution            | string |         |   true   |
-| `location`            | Location of the Azure resources | string | WestUS3 |  false   |
-| `fabric_capacity_sku` | Fabric Capacity SKU name        | string | F2      |  false   |
-| `subscription_id`     | The Azure subscription ID       | string |         |   true   |
+| Name                         | Description                                       | Type        | Default | Required |
+|------------------------------|---------------------------------------------------|-------------|---------|:--------:|
+| `subscription_id`            | The Azure subscription ID                         | string      |         |   true   |
+| `solution_name`              | Name of the solution                              | string      |         |   true   |
+| `location`                   | Location of the Azure resources                   | string      | WestUS3 |  false   |
+| `fabric_capacity_sku`        | Fabric Capacity SKU name                          | string      | F2      |  false   |
+| `fabric_capacity_admin_upns` | Collection of admin UPNs for the Fabric Capacity. | set(string) |         |  false   |
 
 ## Output Values
 

--- a/quickstarts/102-fabric-capacity/main.tf
+++ b/quickstarts/102-fabric-capacity/main.tf
@@ -2,52 +2,61 @@
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config
 data "azurerm_client_config" "example" {}
 
-# Gets information about Entra user.
+# Check the directory object type.
+# https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/directory_object
+data "azuread_directory_object" "example" {
+  object_id = data.azurerm_client_config.example.object_id
+}
+
+# Get information about Entra user.
 # https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user
 data "azuread_user" "example" {
   object_id = data.azurerm_client_config.example.object_id
 }
 
+locals {
+  # Check if the client is a user or not, if it is a user then use the user principal name otherwise use the object id for service principal.
+  fabric_admin = can(data.azuread_directory_object.example.type == "User") ? data.azuread_user.example.user_principal_name : data.azurerm_client_config.example.object_id
+}
+
 # Create a resource group.
 # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group
 resource "azurerm_resource_group" "example" {
-  name     = "rg-${var.name}"
+  name     = "rg-${var.solution_name}"
   location = var.location
 }
 
 # Create a Fabric Capacity.
-# https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/azapi_resource
-resource "azapi_resource" "fabric_capacity_example" {
-  type                      = "Microsoft.Fabric/capacities@2023-11-01"
-  name                      = "fc${var.name}"
-  parent_id                 = azurerm_resource_group.example.id
-  location                  = var.location
-  schema_validation_enabled = false
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/fabric_capacity
+resource "azurerm_fabric_capacity" "example" {
+  name                = "fc${var.solution_name}"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = var.location
 
-  body = {
-    sku = {
-      name = var.fabric_capacity_sku
-      tier = "Fabric"
-    }
-    properties = {
-      administration = {
-        members = [
-          data.azuread_user.example.user_principal_name
-        ]
-      }
-    }
+  administration_members = setunion([local.fabric_admin], var.fabric_capacity_admin_upns)
+
+  sku {
+    name = var.fabric_capacity_sku
+    tier = "Fabric"
   }
 }
 
 # Get the Fabric Capacity details.
 # https://registry.terraform.io/providers/microsoft/fabric/latest/docs/data-sources/capacity
 data "fabric_capacity" "example" {
-  display_name = azapi_resource.fabric_capacity_example.name
+  display_name = azurerm_fabric_capacity.example.name
+
+  lifecycle {
+    postcondition {
+      condition     = self.state == "Active"
+      error_message = "Fabric Capacity is not in Active state. Please check the Fabric Capacity status."
+    }
+  }
 }
 
 # Create a Fabric Workspace.
 # https://registry.terraform.io/providers/microsoft/fabric/latest/docs/resources/workspace
 resource "fabric_workspace" "example" {
   capacity_id  = data.fabric_capacity.example.id
-  display_name = "ws-${var.name}"
+  display_name = "ws-${var.solution_name}"
 }

--- a/quickstarts/102-fabric-capacity/providers.tf
+++ b/quickstarts/102-fabric-capacity/providers.tf
@@ -6,11 +6,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.14.0"
     }
-    # https://registry.terraform.io/providers/Azure/azapi/latest
-    azapi = {
-      source  = "Azure/azapi"
-      version = "2.1.0"
-    }
     # https://registry.terraform.io/providers/hashicorp/azuread/latest
     azuread = {
       source  = "hashicorp/azuread"
@@ -26,12 +21,6 @@ terraform {
 
 provider "azurerm" {
   features {}
-  # Configuration options
-
-  subscription_id = var.subscription_id
-}
-
-provider "azapi" {
   # Configuration options
 
   subscription_id = var.subscription_id

--- a/quickstarts/102-fabric-capacity/variables.tf
+++ b/quickstarts/102-fabric-capacity/variables.tf
@@ -1,21 +1,42 @@
-variable "name" {
+variable "subscription_id" {
+  description = "The Azure subscription ID"
+  type        = string
+  sensitive   = false
+  nullable    = false
+}
+
+variable "solution_name" {
   description = "Name of the solution"
   type        = string
+  sensitive   = false
+  nullable    = false
 }
 
 variable "location" {
   description = "Location of the Azure resources"
   type        = string
+  sensitive   = false
+  nullable    = false
   default     = "WestUS3"
 }
 
 variable "fabric_capacity_sku" {
   description = "Fabric Capacity SKU name"
   type        = string
+  sensitive   = false
+  nullable    = false
   default     = "F2"
+
+  validation {
+    condition     = contains(["F2", "F4", "F8", "F16", "F32", "F64", "F128", "F256", "F512", "F1024", "F2048"], var.fabric_capacity_sku)
+    error_message = "Please specify a valid Fabric Capacity SKU. Valid values are: [ 'F2', 'F4', 'F8', 'F16', 'F32', 'F64', 'F128', 'F256', 'F512', 'F1024', 'F2048' ]."
+  }
 }
 
-variable "subscription_id" {
-  description = "The Azure subscription ID"
-  type        = string
+variable "fabric_capacity_admin_upns" {
+  description = "Collection of admin UPNs for the Fabric Capacity."
+  type        = set(string)
+  sensitive   = false
+  nullable    = false
+  default     = []
 }


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes several updates to the `quickstarts/102-fabric-capacity` Terraform configuration to improve resource management and streamline the code. The most important changes include renaming variables for better clarity, updating resource definitions, and removing the `azapi` provider in favor of `azurerm`.

## ✨ Description of new changes

### Variable Renaming and Updates:
* Renamed the `name` variable to `solution_name` and added a new variable `subscription_id` in `variables.tf` for better clarity.
* Updated `README.md` to reflect the changes in variable names and added descriptions for new variables.

### Resource Definition Updates:
* Replaced the `azapi_resource` with `azurerm_fabric_capacity` in `main.tf` to use the appropriate provider for managing Fabric Capacity resources.
* Added a local variable `fabric_admin` to conditionally set the admin UPNs based on the client type.

### Provider Configuration Changes:
* Removed the `azapi` provider from `providers.tf` as it is no longer needed. [[1]](diffhunk://#diff-6969666e2aaabb3b96ea50fe183a7f4155748d8c5c21595d035519e005588b1eL9-L13) [[2]](diffhunk://#diff-6969666e2aaabb3b96ea50fe183a7f4155748d8c5c21595d035519e005588b1eL34-L39)