### PR TITLE
fix(check_pr): disable cache for go setup

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           go-version: stable
           check-latest: true
+          cache: false
 
       - name: 🚧 Setup Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0


### PR DESCRIPTION
# 📥 Pull Request

## ❓ What are you trying to address

This pull request includes a minor update to the GitHub Actions workflow configuration. The change disables caching for the Go setup step in the `.github/workflows/check_pr.yml` file.
